### PR TITLE
Water level trigger

### DIFF
--- a/src/cache/change-writer.js
+++ b/src/cache/change-writer.js
@@ -14,7 +14,7 @@ class ChangeWriter {
   async add(key, obj) {
     let value = JSON.stringify(obj)
     await this.client.lpush(key, value)
-    await this.client.ltrim(key, 0, this.maxElements - 1)
+    await this.client.ltrim(key, 0, this.maxElements)
   }
 
   /**

--- a/src/cache/change-writer.js
+++ b/src/cache/change-writer.js
@@ -14,7 +14,7 @@ class ChangeWriter {
   async add(key, obj) {
     let value = JSON.stringify(obj)
     await this.client.lpush(key, value)
-    await this.client.ltrim(key, 0, this.maxElements)
+    await this.client.ltrim(key, 0, this.maxElements - 1)
   }
 
   /**

--- a/src/controllers/water-level-changes.js
+++ b/src/controllers/water-level-changes.js
@@ -7,7 +7,7 @@ const URL = 'https://data.edmonton.ca/resource/cnsu-iagr.json' // The Socrata ap
 const QUERY_BASE = `${URL}?$query=`
 
 /**
- * Water Level Changes
+ * Water Level Changes (North Saskatchewan River at Edmonton)
  */
 module.exports = async function(req, res) {
   console.log('Water Level Changes Controller')
@@ -83,10 +83,10 @@ module.exports = async function(req, res) {
 }
 
 /**
- * This function obtains the upper and lower bounds of a period
+ * This function obtains the upper and lower bounds of a time period
  * @param {String} date The date in ISO format
  * @param {Number} days The number of days the period should be
- * @returns {Array<String>} The upper and lower bounds of the period
+ * @returns {Array<String>} The upper and lower bounds of the time period
  */
 function getBounds(date, days) {
   const dateRegex = /[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}.[0-9]{3}/
@@ -100,7 +100,7 @@ function getBounds(date, days) {
 }
 
 /**
- * Returns the average and bounds respecitvely in an array
+ * Returns the average and delta of the water levels respecitvely in an array
  * @param {Array<String>} bounds The bounds to do calculation on (dates in ISO 8601 format)
  * @returns {Array<Number>} The average and delta of the water level between the specified bounds
  */

--- a/src/controllers/water-level-changes.js
+++ b/src/controllers/water-level-changes.js
@@ -1,0 +1,129 @@
+const request = require('request-promise-native')
+const uuid = require('uuid/v4')
+
+const TIMEZONE_OFFSET_MILLIS = 360 * 60 * 1000 // Timezone offset for Edmonton to UTC
+const KEY = 'water-level-changes' // Unique key for dataset storage
+const URL = 'https://data.edmonton.ca/resource/cnsu-iagr.json' // The Socrata api endpoint
+const QUERY_BASE = `${URL}?$query=`
+
+/**
+ * Water Level Changes
+ */
+module.exports = async function(req, res) {
+  console.log('Water Level Changes Controller')
+  let storedData = await req.cache.getLatest(KEY)
+  let storedUpdated
+  if (storedData) storedUpdated = storedData.last_updated
+
+  let getUpdatedQuery = `${QUERY_BASE}
+    SELECT date_and_time, water_level_m
+    WHERE station_number = '05DF001'
+    ORDER BY date_and_time DESC
+    LIMIT 1`
+  let updatedData
+  let recentUpdated
+  try {
+    let rawJsonUpdated = await request(getUpdatedQuery)
+    updatedData = JSON.parse(rawJsonUpdated)
+    recentUpdated = updatedData[0].date_and_time
+  } catch (e) {
+    e.code = 500
+    throw e
+  }
+
+  let responseValues
+  if (storedUpdated && new Date(storedUpdated) >= new Date(recentUpdated)) {
+    console.log('No new updates')
+    responseValues = await req.cache.getAll(KEY, req.body['limit'])
+  } else {
+    console.log('Dataset was updated')
+    let oneDayBounds = getBounds(recentUpdated, 1)
+    let threeDaysBounds = getBounds(recentUpdated, 3)
+    let oneWeekBounds = getBounds(recentUpdated, 7)
+    let oneDayResults
+    let threeDaysResults
+    let oneWeekResults
+    try {
+      await Promise.all(
+        (oneDayResults = await getData(oneDayBounds)),
+        (threeDaysResults = await getData(threeDaysBounds)),
+        (oneWeekResults = await getData(oneWeekBounds))
+      )
+    } catch (e) {
+      e.code = 500
+      throw e
+    }
+    console.log('Adding new rows')
+    let id = uuid()
+    let newRows = {
+      id,
+      created_at: new Date(Date.now()).toISOString(),
+      last_updated: recentUpdated,
+      one_day_average: oneDayResults[0].toFixed(3),
+      one_day_delta: oneDayResults[1].toFixed(3),
+      three_day_average: threeDaysResults[0].toFixed(3),
+      three_day_delta: threeDaysResults[1].toFixed(3),
+      one_week_average: oneWeekResults[0].toFixed(3),
+      one_week_delta: oneWeekResults[1].toFixed(3),
+      meta: {
+        id,
+        timestamp: Math.round(new Date() / 1000)
+      }
+    }
+    req.cache.add(KEY, newRows)
+    responseValues = await req.cache.getAll(KEY, req.body['limit'])
+  }
+
+  res.status(200).send({
+    data: responseValues
+  })
+}
+
+/**
+ * This function obtains the upper and lower bounds of a period
+ * @param {String} date The date in ISO format
+ * @param {Number} days The number of days the period should be
+ * @returns {Array<String>} The upper and lower bounds of the period
+ */
+function getBounds(date, days) {
+  const dateRegex = /[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}.[0-9]{3}/
+  let currentDate = new Date(new Date(date) - TIMEZONE_OFFSET_MILLIS)
+  let threeDayPeriod = new Date(
+    new Date(date) - (days * 24 * 60 * 60 * 1000 + TIMEZONE_OFFSET_MILLIS)
+  )
+  let lowerBound = threeDayPeriod.toISOString().match(dateRegex)[0]
+  let upperBound = currentDate.toISOString().match(dateRegex)[0]
+  return [lowerBound, upperBound]
+}
+
+/**
+ * Returns the average and bounds respecitvely in an array
+ * @param {Array<String>} bounds The bounds to do calculation on (dates in ISO 8601 format)
+ * @returns {Array<Number>} The average and delta of the water level between the specified bounds
+ */
+async function getData(bounds) {
+  let workingDataQuery = `${QUERY_BASE}
+    SELECT water_level_m
+    WHERE station_number = '05DF001'
+    AND date_and_time
+    BETWEEN '${bounds[0]}'
+    AND '${bounds[1]}'
+    ORDER BY date_and_time DESC
+    LIMIT 10000`
+  let workingData
+  try {
+    let rawJsonData = await request(workingDataQuery)
+    workingData = JSON.parse(rawJsonData).map(data => {
+      return Number(data.water_level_m)
+    })
+  } catch (e) {
+    e.code = 500
+    throw e
+  }
+  let delta = workingData[0] - workingData[workingData.length - 1]
+  let sum = workingData.reduce(function(a, b) {
+    return a + b
+  })
+  let average = sum / workingData.length
+  return [average, delta]
+}

--- a/src/controllers/water-level-changes.js
+++ b/src/controllers/water-level-changes.js
@@ -88,6 +88,8 @@ module.exports = async function(req, res) {
     }
     console.log('Adding new rows')
     let id = uuid()
+    // Note: Delta values are calculated by taking the difference of the averages between the
+    // earliest and latest days of the specified time period.
     let newRows = {
       id,
       created_at: new Date(Date.now()).toISOString(),

--- a/src/controllers/water-level-changes.js
+++ b/src/controllers/water-level-changes.js
@@ -5,6 +5,7 @@ const TIMEZONE_OFFSET_MILLIS = 360 * 60 * 1000 // Timezone offset for Edmonton t
 const KEY = 'water-level-changes' // Unique key for dataset storage
 const URL = 'https://data.edmonton.ca/resource/cnsu-iagr.json' // The Socrata api endpoint
 const QUERY_BASE = `${URL}?$query=`
+const STATION_NUMBER = '05DF001' // 05DF001 refers to the water station near the low-level bridge by the North Saskatchewan River at Edmonton
 
 /**
  * Water Level Changes (North Saskatchewan River at Edmonton)
@@ -17,10 +18,9 @@ module.exports = async function(req, res) {
     storedUpdated = storedData.last_updated
   }
 
-  // Note: station number 05DF001 refers to the water station near the low-level bridge by the North Saskatchewan River at Edmonton
   let getUpdatedQuery = `${QUERY_BASE}
     SELECT date_and_time, water_level_m
-    WHERE station_number = '05DF001'
+    WHERE station_number = '${STATION_NUMBER}'
     ORDER BY date_and_time DESC
     LIMIT 1`
   let updatedData
@@ -110,7 +110,7 @@ function getBounds(date, days) {
 async function getData(bounds) {
   let workingDataQuery = `${QUERY_BASE}
     SELECT water_level_m
-    WHERE station_number = '05DF001'
+    WHERE station_number = '${STATION_NUMBER}'
     AND date_and_time
     BETWEEN '${bounds[0]}'
     AND '${bounds[1]}'

--- a/src/controllers/water-level-changes.js
+++ b/src/controllers/water-level-changes.js
@@ -13,8 +13,11 @@ module.exports = async function(req, res) {
   console.log('Water Level Changes Controller')
   let storedData = await req.cache.getLatest(KEY)
   let storedUpdated
-  if (storedData) storedUpdated = storedData.last_updated
+  if (storedData) {
+    storedUpdated = storedData.last_updated
+  }
 
+  // Note: station number 05DF001 refers to the water station near the low-level bridge by the North Saskatchewan River at Edmonton
   let getUpdatedQuery = `${QUERY_BASE}
     SELECT date_and_time, water_level_m
     WHERE station_number = '05DF001'
@@ -90,12 +93,12 @@ module.exports = async function(req, res) {
  */
 function getBounds(date, days) {
   const dateRegex = /[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}.[0-9]{3}/
-  let currentDate = new Date(new Date(date) - TIMEZONE_OFFSET_MILLIS)
-  let threeDayPeriod = new Date(
+  let endOfPeriod = new Date(new Date(date) - TIMEZONE_OFFSET_MILLIS)
+  let startOfPeriod = new Date(
     new Date(date) - (days * 24 * 60 * 60 * 1000 + TIMEZONE_OFFSET_MILLIS)
   )
-  let lowerBound = threeDayPeriod.toISOString().match(dateRegex)[0]
-  let upperBound = currentDate.toISOString().match(dateRegex)[0]
+  let lowerBound = startOfPeriod.toISOString().match(dateRegex)[0]
+  let upperBound = endOfPeriod.toISOString().match(dateRegex)[0]
   return [lowerBound, upperBound]
 }
 

--- a/src/controllers/water-level-changes.js
+++ b/src/controllers/water-level-changes.js
@@ -22,10 +22,12 @@ module.exports = async function(req, res) {
     LIMIT 1`
   let updatedData
   let recentUpdated
+  let recentWaterLevel
   try {
     let rawJsonUpdated = await request(getUpdatedQuery)
     updatedData = JSON.parse(rawJsonUpdated)
     recentUpdated = updatedData[0].date_and_time
+    recentWaterLevel = updatedData[0].water_level_m
   } catch (e) {
     e.code = 500
     throw e
@@ -59,6 +61,7 @@ module.exports = async function(req, res) {
       id,
       created_at: new Date(Date.now()).toISOString(),
       last_updated: recentUpdated,
+      latest_water_level: recentWaterLevel,
       one_day_average: oneDayResults[0].toFixed(3),
       one_day_delta: oneDayResults[1].toFixed(3),
       three_day_average: threeDaysResults[0].toFixed(3),

--- a/src/controllers/water-level-changes.js
+++ b/src/controllers/water-level-changes.js
@@ -1,7 +1,7 @@
 const request = require('request-promise-native')
 const uuid = require('uuid/v4')
 
-const TIMEZONE_OFFSET_MILLIS = 360 * 60 * 1000 // Timezone offset for Edmonton to UTC
+const TIMEZONE_OFFSET_MILLIS = -1 * 360 * 60 * 1000 // Timezone offset for Edmonton to UTC
 const KEY = 'water-level-changes' // Unique key for dataset storage
 const URL = 'https://data.edmonton.ca/resource/cnsu-iagr.json' // The Socrata api endpoint
 const QUERY_BASE = `${URL}?$query=`
@@ -30,7 +30,7 @@ module.exports = async function(req, res) {
     let rawJsonUpdated = await request(getUpdatedQuery)
     updatedData = JSON.parse(rawJsonUpdated)
     recentUpdated = updatedData[0].date_and_time
-    recentWaterLevel = updatedData[0].water_level_m
+    recentWaterLevel = Number(updatedData[0].water_level_m)
   } catch (e) {
     e.code = 500
     throw e
@@ -42,18 +42,46 @@ module.exports = async function(req, res) {
     responseValues = await req.cache.getAll(KEY, req.body['limit'])
   } else {
     console.log('Dataset was updated')
-    let oneDayBounds = getBounds(recentUpdated, 1)
-    let threeDaysBounds = getBounds(recentUpdated, 3)
-    let oneWeekBounds = getBounds(recentUpdated, 7)
-    let oneDayResults
-    let threeDaysResults
-    let oneWeekResults
+    let currentDay = getBounds(recentUpdated, {
+      timeZoneOffset: TIMEZONE_OFFSET_MILLIS
+    })
+    let previousDay = getBounds(recentUpdated, {
+      timeZoneOffset: TIMEZONE_OFFSET_MILLIS,
+      offset: -1
+    })
+    let threeDaySpan = getBounds(recentUpdated, {
+      timeZoneOffset: TIMEZONE_OFFSET_MILLIS,
+      offset: -2,
+      span: true
+    })
+    let threeDaysAgo = getBounds(recentUpdated, {
+      timeZoneOffset: TIMEZONE_OFFSET_MILLIS,
+      offset: -2
+    })
+    let oneWeekSpan = getBounds(recentUpdated, {
+      timeZoneOffset: TIMEZONE_OFFSET_MILLIS,
+      offset: -6,
+      span: true
+    })
+    let oneWeekAgo = getBounds(recentUpdated, {
+      timeZoneOffset: TIMEZONE_OFFSET_MILLIS,
+      offset: -6
+    })
+    let currentDayAvg
+    let previousDayAvg
+    let threeDaySpanAvg
+    let threeDaysAgoAvg
+    let oneWeekSpanAvg
+    let oneWeekAgoAvg
     try {
-      await Promise.all(
-        (oneDayResults = await getData(oneDayBounds)),
-        (threeDaysResults = await getData(threeDaysBounds)),
-        (oneWeekResults = await getData(oneWeekBounds))
-      )
+      await Promise.all([
+        (currentDayAvg = await queryData(currentDay)),
+        (previousDayAvg = await queryData(previousDay)),
+        (threeDaySpanAvg = await queryData(threeDaySpan)),
+        (threeDaysAgoAvg = await queryData(threeDaysAgo)),
+        (oneWeekSpanAvg = await queryData(oneWeekSpan)),
+        (oneWeekAgoAvg = await queryData(oneWeekAgo))
+      ])
     } catch (e) {
       e.code = 500
       throw e
@@ -64,13 +92,19 @@ module.exports = async function(req, res) {
       id,
       created_at: new Date(Date.now()).toISOString(),
       last_updated: recentUpdated,
-      latest_water_level: recentWaterLevel,
-      one_day_average: oneDayResults[0].toFixed(3),
-      one_day_delta: oneDayResults[1].toFixed(3),
-      three_day_average: threeDaysResults[0].toFixed(3),
-      three_day_delta: threeDaysResults[1].toFixed(3),
-      one_week_average: oneWeekResults[0].toFixed(3),
-      one_week_delta: oneWeekResults[1].toFixed(3),
+      latest_water_level: recentWaterLevel.toFixed(3),
+      one_day_average: currentDayAvg.averageWaterLevel.toFixed(3),
+      one_day_delta: (
+        currentDayAvg.averageWaterLevel - previousDayAvg.averageWaterLevel
+      ).toFixed(3),
+      three_day_average: threeDaySpanAvg.averageWaterLevel.toFixed(3),
+      three_day_delta: (
+        currentDayAvg.averageWaterLevel - threeDaysAgoAvg.averageWaterLevel
+      ).toFixed(3),
+      one_week_average: oneWeekSpanAvg.averageWaterLevel.toFixed(3),
+      one_week_delta: (
+        currentDayAvg.averageWaterLevel - oneWeekAgoAvg.averageWaterLevel
+      ).toFixed(3),
       meta: {
         id,
         timestamp: Math.round(new Date() / 1000)
@@ -86,50 +120,67 @@ module.exports = async function(req, res) {
 }
 
 /**
- * This function obtains the upper and lower bounds of a time period
+ * This function obtains the upper and lower bounds of a the full day of the given date, or it can be used
+ * to get the bounds of date ranges.
  * @param {String} date The date in ISO format
- * @param {Number} days The number of days the period should be
- * @returns {Array<String>} The upper and lower bounds of the time period
+ * @param {Object} [options] The options for the bounds
+ * @param {Number} [options.timeZoneOffset] The time zone offset of the date (optional)
+ * @param {Number} [options.offset] The number of days to offset the current date by (optional)
+ * @param {Boolean} [options.span] If enabled, will return the bounds between the specified date and offset (default: false)
+ * @returns {Array<String>} The upper and lower bounds of the full day
  */
-function getBounds(date, days) {
-  const dateRegex = /[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}.[0-9]{3}/
-  let endOfPeriod = new Date(new Date(date) - TIMEZONE_OFFSET_MILLIS)
-  let startOfPeriod = new Date(
-    new Date(date) - (days * 24 * 60 * 60 * 1000 + TIMEZONE_OFFSET_MILLIS)
-  )
-  let lowerBound = startOfPeriod.toISOString().match(dateRegex)[0]
-  let upperBound = endOfPeriod.toISOString().match(dateRegex)[0]
+function getBounds(date, options) {
+  const dateRegex = /[0-9]{4}-[0-9]{2}-[0-9]{2}/
+  let timeZoneOffset = options.timeZoneOffset || 0
+  let offset = options.offset || 0
+  let span = options.span || false
+  let dayOffset = offset * 24 * 60 * 60 * 1000
+  let dateObject = new Date(date)
+  let referenceDay = new Date(dateObject.getTime() + timeZoneOffset)
+  let day = new Date(dateObject.getTime() + timeZoneOffset + dayOffset)
+  let lowerBound
+  let upperBound
+  if (span) {
+    if (referenceDay > day) {
+      lowerBound = day.toISOString().match(dateRegex)[0] + 'T00:00:00.000'
+      upperBound =
+        referenceDay.toISOString().match(dateRegex)[0] + 'T23:59:59.999'
+    } else {
+      lowerBound =
+        referenceDay.toISOString().match(dateRegex)[0] + 'T00:00:00.000'
+      upperBound = day.toISOString().match(dateRegex)[0] + 'T23:59:59.999'
+    }
+  } else {
+    let returnDay = day.toISOString().match(dateRegex)[0]
+    lowerBound = returnDay + 'T00:00:00.000'
+    upperBound = returnDay + 'T23:59:59.999'
+  }
   return [lowerBound, upperBound]
 }
 
 /**
- * Returns the average and delta of the water levels respecitvely in an array
+ * Queries the API endpoint for the average water level in meters between the specified bounds and the
+ * number of data points within that bound.
  * @param {Array<String>} bounds The bounds to do calculation on (dates in ISO 8601 format)
- * @returns {Array<Number>} The average and delta of the water level between the specified bounds
+ * @returns {Object} The number of data points and average water level between the specified bounds: { dataCount, averageWaterLevel }
  */
-async function getData(bounds) {
-  let workingDataQuery = `${QUERY_BASE}
-    SELECT water_level_m
+async function queryData(bounds) {
+  let dataQuery = `${QUERY_BASE}
+    SELECT count(*), avg(water_level_m)
     WHERE station_number = '${STATION_NUMBER}'
     AND date_and_time
     BETWEEN '${bounds[0]}'
-    AND '${bounds[1]}'
-    ORDER BY date_and_time DESC
-    LIMIT 10000`
-  let workingData
+    AND '${bounds[1]}'`
+  let queryResults
   try {
-    let rawJsonData = await request(workingDataQuery)
-    workingData = JSON.parse(rawJsonData).map(data => {
-      return Number(data.water_level_m)
-    })
+    let rawQueryResults = await request(dataQuery)
+    queryResults = JSON.parse(rawQueryResults)[0]
   } catch (e) {
     e.code = 500
     throw e
   }
-  let delta = workingData[0] - workingData[workingData.length - 1]
-  let sum = workingData.reduce(function(a, b) {
-    return a + b
-  })
-  let average = sum / workingData.length
-  return [average, delta]
+  return {
+    dataCount: Number(queryResults.count),
+    averageWaterLevel: Number(queryResults.avg_water_level_m)
+  }
 }

--- a/src/server.js
+++ b/src/server.js
@@ -32,6 +32,7 @@ const status = require('./controllers/status')
 const test = require('./controllers/test-setup')
 const airQualityStations = require('./controllers/air-quality-stations')
 const lrtEscalatorElevatorOutages = require('./controllers/lrt-escalator-elevator-outages')
+const waterLevelChanges = require('./controllers/water-level-changes')
 
 // Middleware
 const logger = require('./middleware/logger')
@@ -66,6 +67,8 @@ let edmontonAirHealthIndex = createAirQualityController(req => {
     limit: req.body['limit']
   }
 })
+
+router.post('/triggers/water_level_changes', waterLevelChanges)
 
 router.post(
   '/triggers/lrt_escalator_elevator_outages',


### PR DESCRIPTION
Closes #57

The service endpoint for the trigger on the Edmonton Open Data Portal [*Water Levels and Flows*](https://data.edmonton.ca/dataset/Water-Levels-and-Flows/cnsu-iagr) dataset.

This trigger gives back the average and delta of the water levels over a one day, three day, and one week period or the North Saskatchewan River at Edmonton. It also gives back a "*latest water level*" measurement ingredient.

This triggers whenever the dataset is updated since the dataset being watched is not updated in real-time.

List of ingredients:
- **latest_water_level**: The most recent water level recorded to the database
- **one_day_average**: The most recent one-day average of the water level
- **one_day_delta**: The difference in the average water levels between the latest day and the day prior
- **three_day_average**: The most recent three-day average of the water level
- **three_day_delta**: The difference in the average water levels between the latest day and three days prior
- **one_week_average**: The most recent one-week average of the water level
- **one_week_delta**: The difference in the average water levels between the latest day and one week prior

*Note*: All water level calculations are in **meters**