### PR TITLE
String and HTML ingredient for LRT Escalator/Elevator Outages trigger

### DIFF
--- a/src/controllers/lrt-escalator-elevator-outages.js
+++ b/src/controllers/lrt-escalator-elevator-outages.js
@@ -58,8 +58,12 @@ module.exports = async function(req, res) {
     let newRows = {
       id,
       created_at: latestTimestamp,
-      outages: JSON.stringify(latestColumnRows),
-      fixed: JSON.stringify(fixed),
+      outages_json: JSON.stringify(latestColumnRows),
+      fixed_json: JSON.stringify(fixed),
+      outages_string: stringData(latestColumnRows),
+      fixed_string: stringData(fixed),
+      outages_html: htmlData(latestColumnRows),
+      fixed_html: htmlData(fixed),
       meta: {
         id,
         timestamp: Math.round(new Date() / 1000)
@@ -72,6 +76,38 @@ module.exports = async function(req, res) {
   res.status(200).send({
     data: responseValues
   })
+}
+
+/**
+ * Uses \n newline to format the data
+ * @param {Object} data The JSON object with outages information
+ * @returns {String} Formatted data
+ */
+function stringData(data) {
+  return data
+    .map(entry => {
+      return `\n- ${entry.lrt_station_name} ${entry.device_type}: ${
+        entry.lrt_device_location
+      }`
+    })
+    .sort()
+    .toString()
+}
+
+/**
+ * Uses <br> tags to format the data
+ * @param {Object} data The JSON object with outages information
+ * @returns {String} Formatted data
+ */
+function htmlData(data) {
+  return data
+    .map(entry => {
+      return `<br>- ${entry.lrt_station_name} ${entry.device_type}: ${
+        entry.lrt_device_location
+      }</br>`
+    })
+    .sort()
+    .toString()
 }
 
 /**

--- a/src/controllers/lrt-escalator-elevator-outages.js
+++ b/src/controllers/lrt-escalator-elevator-outages.js
@@ -68,6 +68,8 @@ module.exports = async function(req, res) {
       fixed_html: formatData(fixed, '<br>- '),
       outages_csv: formatData(latestColumnRows, ''),
       fixed_csv: formatData(fixed, ''),
+      outages: JSON.stringify(latestColumnRows), // Old ingredients (Should be removed once trigger updated)
+      fixed: JSON.stringify(fixed), // Old ingredients (Should be removed once trigger updated)
       meta: {
         id,
         timestamp: Math.round(new Date() / 1000)

--- a/src/controllers/lrt-escalator-elevator-outages.js
+++ b/src/controllers/lrt-escalator-elevator-outages.js
@@ -15,9 +15,11 @@ module.exports = async function(req, res) {
   let filteredStoredColumnValues // The stored/previous column values to be compared to
   if (storedData) {
     storedTimestamp = storedData.created_at
-    filteredStoredColumnValues = JSON.parse(storedData.outages).map(device => {
-      return device.device_id
-    })
+    filteredStoredColumnValues = JSON.parse(storedData.outages_json).map(
+      device => {
+        return device.device_id
+      }
+    )
   } else {
     storedTimestamp = '1998-07-25T00:00:00.000Z' // This value is random
   }
@@ -81,7 +83,7 @@ module.exports = async function(req, res) {
 }
 
 /**
- * Uses \n newline to format the data
+ * Uses linebreaks to format the data
  * @param {Object} data The JSON object with outages information
  * @param {String} lineBreak The linebreak to use
  * @returns {String} Formatted data
@@ -131,8 +133,8 @@ function compareArr(arr1, arr2) {
 function arrDiffFixed(storedData, latestDeviceIds) {
   let fixed = []
   if (!storedData) return fixed
-  if (!latestDeviceIds) return storedData.outages
-  for (let element of JSON.parse(storedData.outages)) {
+  if (!latestDeviceIds) return storedData.outages_json
+  for (let element of JSON.parse(storedData.outages_json)) {
     if (latestDeviceIds.indexOf(element.device_id) == -1) {
       fixed.push(element)
     }

--- a/src/controllers/lrt-escalator-elevator-outages.js
+++ b/src/controllers/lrt-escalator-elevator-outages.js
@@ -60,10 +60,12 @@ module.exports = async function(req, res) {
       created_at: latestTimestamp,
       outages_json: JSON.stringify(latestColumnRows),
       fixed_json: JSON.stringify(fixed),
-      outages_string: stringData(latestColumnRows),
-      fixed_string: stringData(fixed),
-      outages_html: htmlData(latestColumnRows),
-      fixed_html: htmlData(fixed),
+      outages_string: formatData(latestColumnRows, '\n- '),
+      fixed_string: formatData(fixed, '\n- '),
+      outages_html: formatData(latestColumnRows, '<br>- '),
+      fixed_html: formatData(fixed, '<br>- '),
+      outages_csv: formatData(latestColumnRows, ''),
+      fixed_csv: formatData(fixed, ''),
       meta: {
         id,
         timestamp: Math.round(new Date() / 1000)
@@ -81,30 +83,15 @@ module.exports = async function(req, res) {
 /**
  * Uses \n newline to format the data
  * @param {Object} data The JSON object with outages information
+ * @param {String} lineBreak The linebreak to use
  * @returns {String} Formatted data
  */
-function stringData(data) {
+function formatData(data, lineBreak) {
   return data
     .map(entry => {
-      return `\n- ${entry.lrt_station_name} ${entry.device_type}: ${
+      return `${lineBreak}${entry.lrt_station_name} ${entry.device_type}: ${
         entry.lrt_device_location
       }`
-    })
-    .sort()
-    .toString()
-}
-
-/**
- * Uses <br> tags to format the data
- * @param {Object} data The JSON object with outages information
- * @returns {String} Formatted data
- */
-function htmlData(data) {
-  return data
-    .map(entry => {
-      return `<br>- ${entry.lrt_station_name} ${entry.device_type}: ${
-        entry.lrt_device_location
-      }</br>`
     })
     .sort()
     .toString()


### PR DESCRIPTION
PR for #89

Adds a string and HTML formatted ingredient for the existing trigger. Ingredients have been changed to:
- **outages_json**: A stringified JSON object with outages information
- **fixed_json**: A stringified JSON object with fixed devices information
- **outages_string**: A string formatted version of *outages_json*
- **fixed_string**: A string formatted version of *fixed_json*
- **outages_html**: An HTML formatted version of *outages_json* using ```</br>``` tags
- **fixed_html**: An HTML formatted version of *fixed_json* using ```</br>``` tags
- **outages_csv**: A CSV formatted version of *outages_json*
- **fixed_csv**: A CSV formatted version of *fixed_json*

*Note:* the existing trigger on the IFTTT platform has to be updated with the new ingredients
